### PR TITLE
fix regular expressions for routing

### DIFF
--- a/databases/bookstore/burts_books_rwdb.py
+++ b/databases/bookstore/burts_books_rwdb.py
@@ -18,7 +18,7 @@ class Application(tornado.web.Application):
 		handlers = [
 			(r"/", MainHandler),
 			(r"/recommended/", RecommendedHandler),
-			(r"/edit/([0-9\-]+)", BookEditHandler),
+			(r"/edit/([0-9Xx\-]+)", BookEditHandler),
 			(r"/add", BookEditHandler)
 		]
 		settings = dict(

--- a/databases/bookstore/burts_books_rwdb_single.py
+++ b/databases/bookstore/burts_books_rwdb_single.py
@@ -18,8 +18,8 @@ class Application(tornado.web.Application):
 		handlers = [
 			(r"/", MainHandler),
 			(r"/recommended/", RecommendedHandler),
-			(r"/books/([0-9\-]+)", BookHandler),
-			(r"/edit/([0-9\-]+)", BookEditHandler),
+			(r"/books/([0-9Xx\-]+)", BookHandler),
+			(r"/edit/([0-9Xx\-]+)", BookEditHandler),
 			(r"/add", BookEditHandler)
 		]
 		settings = dict(


### PR DESCRIPTION
This is a sample code fix for Ch.4 Databases : Editing and Adding Books

If you run the sample code and 'X' or 'x' is included in ISBN number, the server raises an error.
Sample codes listed in the book is OK, but the code here at github has this bug.
