### PR TITLE
fix non-ascii character encoding problem

### DIFF
--- a/asynchronous_web_services/async_http/tweet_rate.py
+++ b/asynchronous_web_services/async_http/tweet_rate.py
@@ -17,7 +17,7 @@ class IndexHandler(tornado.web.RequestHandler):
 		query = self.get_argument('q')
 		client = tornado.httpclient.HTTPClient()
 		response = client.fetch("http://search.twitter.com/search.json?" + \
-				urllib.urlencode({"q": query, "result_type": "recent", "rpp": 100}))
+				urllib.urlencode({"q": query.encode('utf8'), "result_type": "recent", "rpp": 100}))
 		body = json.loads(response.body)
 		result_count = len(body['results'])
 		now = datetime.datetime.utcnow()

--- a/asynchronous_web_services/async_http/tweet_rate_async.py
+++ b/asynchronous_web_services/async_http/tweet_rate_async.py
@@ -18,7 +18,7 @@ class IndexHandler(tornado.web.RequestHandler):
 		query = self.get_argument('q')
 		client = tornado.httpclient.AsyncHTTPClient()
 		client.fetch("http://search.twitter.com/search.json?" + \
-				urllib.urlencode({"q": query, "result_type": "recent", "rpp": 100}),
+				urllib.urlencode({"q": query.encode('utf8'), "result_type": "recent", "rpp": 100}),
 				callback=self.on_response)
 
 	def on_response(self, response):

--- a/asynchronous_web_services/async_http/tweet_rate_gen.py
+++ b/asynchronous_web_services/async_http/tweet_rate_gen.py
@@ -21,7 +21,7 @@ class IndexHandler(tornado.web.RequestHandler):
 		client = tornado.httpclient.AsyncHTTPClient()
 		response = yield tornado.gen.Task(client.fetch,
 				"http://search.twitter.com/search.json?" + \
-				urllib.urlencode({"q": query, "result_type": "recent", "rpp": 100}))
+				urllib.urlencode({"q": query.encode('utf8'), "result_type": "recent", "rpp": 100}))
 		body = json.loads(response.body)
 		result_count = len(body['results'])
 		now = datetime.datetime.utcnow()


### PR DESCRIPTION
 tornado.web.RequestHandler.get_argument returns a unicode string.
  http://www.tornadoweb.org/documentation/web.html?#tornado.web.RequestHandler.get_argument

And urllib.urlencode converts unicode chars into string chars before percent-encoding them.
If an argument contains non-ascii characters, encoding(default charset is system dependent) results in UnicodeEncodeError.

Example query:
  http://HOST:8000/?q=%E3%83%88%E3%83%AB%E3%83%8D%E3%83%BC%E3%83%89
