### PR TITLE
Fix for TypeError in string_service.py

### DIFF
--- a/simple_web_services/string_service.py
+++ b/simple_web_services/string_service.py
@@ -16,7 +16,7 @@ class WrapHandler(tornado.web.RequestHandler):
 	def post(self):
 		text = self.get_argument('text')
 		width = self.get_argument('width', 40)
-		self.write(textwrap.fill(text, width))
+		self.write(textwrap.fill(text, int(width)))
 
 if __name__ == "__main__":
 	tornado.options.parse_command_line()


### PR DESCRIPTION
TypeError: unsupported operand type(s) for -: 'unicode' and 'int' in string_service.py when passing the "width" parameter
