### PR TITLE
The word Static is added automatically

### DIFF
--- a/extending_templates/bookstore/main.py
+++ b/extending_templates/bookstore/main.py
@@ -109,10 +109,10 @@ class BookModule(tornado.web.UIModule):
 		)
 	
 	def css_files(self):
-		return "/static/css/recommended.css"
+		return "css/recommended.css"
 	
 	def javascript_files(self):
-		return "/static/js/recommended.js"
+		return "js/recommended.js"
 
 
 def main():


### PR DESCRIPTION
When usng UIModules, static word is used automatically as a suffix.