### PR TITLE
Connection issue and twitter 1.1 API issues.

### DIFF
--- a/asynchronous_web_services/async_http/tweet_rate.py
+++ b/asynchronous_web_services/async_http/tweet_rate.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 import tornado.httpserver
 import tornado.ioloop
 import tornado.options
@@ -12,49 +14,51 @@ import datetime
 import time
 
 from tornado.options import define, options
-define('port', default=8000, help = 'run on the given port', type = int)
+define('port', default=8000, help='run on the given port', type=int)
 
 # twitter part
+
 client_key = 'NqHKwxVhm7Fk4257bzgAidOsN'
-client_secret = 'dlOeX6TtGffsdafxqhz46rNRT6kfaPoQEN2qnkknSSodhxPIICnMuMR'
+client_secret = 'dlOeX6TtGfxqhz46rNRT6kfaPoQEN2qnkknSSodhxPIICnMuMR'
 key_secret = '{}:{}'.format(client_key, client_secret).encode('ascii')
 b64_encoded_key = base64.b64encode(key_secret)
 b64_encoded_key = b64_encoded_key.decode('ascii')
 base_url = 'https://api.twitter.com/'
 auth_url = '{}oauth2/token'.format(base_url)
-auth_headers = {
-'Authorization': 'Basic {}'.format(b64_encoded_key),
-'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
-}
-auth_data = {
-'grant_type': 'client_credentials'
-}
-auth_resp = requests.post(auth_url, headers=auth_headers, data=auth_data)
+auth_headers = {'Authorization': 'Basic {}'.format(b64_encoded_key),
+                'Content-Type':
+                'application/x-www-form-urlencoded;charset=UTF-8'
+                }
+auth_data = {'grant_type': 'client_credentials'}
+auth_resp = requests.post(auth_url, headers=auth_headers,
+                          data=auth_data)
 access_token = auth_resp.json()['access_token']
-search_headers = {
-'Authorization': 'Bearer {}'.format(access_token)    
-}
+search_headers = {'Authorization': 'Bearer {}'.format(access_token)}
 search_url = '{}1.1/search/tweets.json?'.format(base_url)
 
+
 class IndexHandler(tornado.web.RequestHandler):
+
     def get(self):
-        query = self.get_argument('q') 
-        search_params = {
-        'q': query,
-        'result_type': 'recent',
-        'count': 100
-        }
+        query = self.get_argument('q')
+        search_params = {'q': query, 'result_type': 'recent',
+                         'count': 100}
 
         client = tornado.httpclient.HTTPClient()
-        response = client.fetch(search_url+urllib.parse.urlencode(search_params), headers=search_headers)
+        response = client.fetch(search_url +
+                                urllib.parse.urlencode(search_params),
+                                headers=search_headers)
         body = json.loads(response.body)
         result_count = len(body['statuses'])
         now = datetime.datetime.utcnow()
         raw_oldest_tweet_at = body['statuses'][-1]['created_at']
-        oldest_tweet_at = datetime.datetime.strptime(raw_oldest_tweet_at,
-                "%a %b %d %H:%M:%S +0000 %Y")
-        seconds_diff = time.mktime(now.timetuple()) - \
-                time.mktime(oldest_tweet_at.timetuple())
+        oldest_tweet_at = \
+            datetime.datetime.strptime(
+                raw_oldest_tweet_at,
+                '%a %b %d %H:%M:%S +0000 %Y'
+                )
+        seconds_diff = time.mktime(now.timetuple()) \
+            - time.mktime(oldest_tweet_at.timetuple())
         tweets_per_second = float(result_count) / seconds_diff
         self.write("""
         <div style="text-align: center">
@@ -63,9 +67,10 @@ class IndexHandler(tornado.web.RequestHandler):
         <div style="font-size: 24px">tweets per second</div>
         </div>""" % (query, tweets_per_second))
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     tornado.options.parse_command_line()
-    app = tornado.web.Application(handlers=[(r"/", IndexHandler)], debug = True)
+    app = tornado.web.Application(handlers=[(r"/", IndexHandler)])
     http_server = tornado.httpserver.HTTPServer(app)
     http_server.listen(options.port)
     tornado.ioloop.IOLoop.current().start()

--- a/asynchronous_web_services/async_http/tweet_rate.py
+++ b/asynchronous_web_services/async_http/tweet_rate.py
@@ -4,39 +4,68 @@ import tornado.options
 import tornado.web
 import tornado.httpclient
 
-import urllib
+import base64
+import requests
+import urllib.parse
 import json
 import datetime
 import time
 
 from tornado.options import define, options
-define("port", default=8000, help="run on the given port", type=int)
+define('port', default=8000, help = 'run on the given port', type = int)
+
+# twitter part
+client_key = 'NqHKwxVhm7Fk4257bzgAidOsN'
+client_secret = 'dlOeX6TtGffsdafxqhz46rNRT6kfaPoQEN2qnkknSSodhxPIICnMuMR'
+key_secret = '{}:{}'.format(client_key, client_secret).encode('ascii')
+b64_encoded_key = base64.b64encode(key_secret)
+b64_encoded_key = b64_encoded_key.decode('ascii')
+base_url = 'https://api.twitter.com/'
+auth_url = '{}oauth2/token'.format(base_url)
+auth_headers = {
+'Authorization': 'Basic {}'.format(b64_encoded_key),
+'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+}
+auth_data = {
+'grant_type': 'client_credentials'
+}
+auth_resp = requests.post(auth_url, headers=auth_headers, data=auth_data)
+access_token = auth_resp.json()['access_token']
+search_headers = {
+'Authorization': 'Bearer {}'.format(access_token)    
+}
+search_url = '{}1.1/search/tweets.json?'.format(base_url)
 
 class IndexHandler(tornado.web.RequestHandler):
-	def get(self):
-		query = self.get_argument('q')
-		client = tornado.httpclient.HTTPClient()
-		response = client.fetch("http://search.twitter.com/search.json?" + \
-				urllib.urlencode({"q": query.encode('utf8'), "result_type": "recent", "rpp": 100}))
-		body = json.loads(response.body)
-		result_count = len(body['results'])
-		now = datetime.datetime.utcnow()
-		raw_oldest_tweet_at = body['results'][-1]['created_at']
-		oldest_tweet_at = datetime.datetime.strptime(raw_oldest_tweet_at,
-				"%a, %d %b %Y %H:%M:%S +0000")
-		seconds_diff = time.mktime(now.timetuple()) - \
-				time.mktime(oldest_tweet_at.timetuple())
-		tweets_per_second = float(result_count) / seconds_diff
-		self.write("""
-<div style="text-align: center">
-	<div style="font-size: 72px">%s</div>
-	<div style="font-size: 144px">%.02f</div>
-	<div style="font-size: 24px">tweets per second</div>
-</div>""" % (query, tweets_per_second))
+    def get(self):
+        query = self.get_argument('q') 
+        search_params = {
+        'q': query,
+        'result_type': 'recent',
+        'count': 100
+        }
+
+        client = tornado.httpclient.HTTPClient()
+        response = client.fetch(search_url+urllib.parse.urlencode(search_params), headers=search_headers)
+        body = json.loads(response.body)
+        result_count = len(body['statuses'])
+        now = datetime.datetime.utcnow()
+        raw_oldest_tweet_at = body['statuses'][-1]['created_at']
+        oldest_tweet_at = datetime.datetime.strptime(raw_oldest_tweet_at,
+                "%a %b %d %H:%M:%S +0000 %Y")
+        seconds_diff = time.mktime(now.timetuple()) - \
+                time.mktime(oldest_tweet_at.timetuple())
+        tweets_per_second = float(result_count) / seconds_diff
+        self.write("""
+        <div style="text-align: center">
+        <div style="font-size: 72px">%s</div>
+        <div style="font-size: 144px">%.02f</div>
+        <div style="font-size: 24px">tweets per second</div>
+        </div>""" % (query, tweets_per_second))
 
 if __name__ == "__main__":
-	tornado.options.parse_command_line()
-	app = tornado.web.Application(handlers=[(r"/", IndexHandler)])
-	http_server = tornado.httpserver.HTTPServer(app)
-	http_server.listen(options.port)
-	tornado.ioloop.IOLoop.instance().start()
+    tornado.options.parse_command_line()
+    app = tornado.web.Application(handlers=[(r"/", IndexHandler)], debug = True)
+    http_server = tornado.httpserver.HTTPServer(app)
+    http_server.listen(options.port)
+    tornado.ioloop.IOLoop.current().start()

--- a/asynchronous_web_services/async_http/tweet_rate_async.py
+++ b/asynchronous_web_services/async_http/tweet_rate_async.py
@@ -4,44 +4,74 @@ import tornado.options
 import tornado.web
 import tornado.httpclient
 
-import urllib
+import base64
+import requests
+import urllib.parse
 import json
 import datetime
 import time
 
 from tornado.options import define, options
-define("port", default=8000, help="run on the given port", type=int)
+define('port', default=8000, help = 'run on the given port', type = int)
+
+# twitter part
+client_key = 'NqHKwxVhm7Fk4257bzgAidOsN'
+client_secret = 'dlOeX6TtGffsdafxqhz46rNRT6kfaPoQEN2qnkknSSodhxPIICnMuMR'
+key_secret = '{}:{}'.format(client_key, client_secret).encode('ascii')
+b64_encoded_key = base64.b64encode(key_secret)
+b64_encoded_key = b64_encoded_key.decode('ascii')
+base_url = 'https://api.twitter.com/'
+auth_url = '{}oauth2/token'.format(base_url)
+auth_headers = {
+'Authorization': 'Basic {}'.format(b64_encoded_key),
+'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+}
+auth_data = {
+'grant_type': 'client_credentials'
+}
+auth_resp = requests.post(auth_url, headers=auth_headers, data=auth_data)
+access_token = auth_resp.json()['access_token']
+search_headers = {
+'Authorization': 'Bearer {}'.format(access_token)    
+}
+search_url = '{}1.1/search/tweets.json?'.format(base_url)
 
 class IndexHandler(tornado.web.RequestHandler):
-	@tornado.web.asynchronous
-	def get(self):
-		query = self.get_argument('q')
-		client = tornado.httpclient.AsyncHTTPClient()
-		client.fetch("http://search.twitter.com/search.json?" + \
-				urllib.urlencode({"q": query.encode('utf8'), "result_type": "recent", "rpp": 100}),
-				callback=self.on_response)
+        @tornado.web.asynchronous
+        def get(self):
+                query = self.get_argument('q') 
+                search_params = {
+                'q': query,
+                'result_type': 'recent',
+                'count': 100
+                }
 
-	def on_response(self, response):
-		body = json.loads(response.body)
-		result_count = len(body['results'])
-		now = datetime.datetime.utcnow()
-		raw_oldest_tweet_at = body['results'][-1]['created_at']
-		oldest_tweet_at = datetime.datetime.strptime(raw_oldest_tweet_at,
-				"%a, %d %b %Y %H:%M:%S +0000")
-		seconds_diff = time.mktime(now.timetuple()) - \
-				time.mktime(oldest_tweet_at.timetuple())
-		tweets_per_second = float(result_count) / seconds_diff
-		self.write("""
-<div style="text-align: center">
-	<div style="font-size: 72px">%s</div>
-	<div style="font-size: 144px">%.02f</div>
-	<div style="font-size: 24px">tweets per second</div>
-</div>""" % (self.get_argument('q'), tweets_per_second))
-		self.finish()
+                client = tornado.httpclient.AsyncHTTPClient()
+                response = client.fetch(search_url+urllib.parse.urlencode(search_params), headers=search_headers,
+                                        callback = self.on_response)
+        
+        def on_response(self, response):       
+                body = json.loads(response.body)
+                result_count = len(body['statuses'])
+                now = datetime.datetime.utcnow()
+                raw_oldest_tweet_at = body['statuses'][-1]['created_at']
+                oldest_tweet_at = datetime.datetime.strptime(raw_oldest_tweet_at,
+                        "%a %b %d %H:%M:%S +0000 %Y")
+                seconds_diff = time.mktime(now.timetuple()) - \
+                        time.mktime(oldest_tweet_at.timetuple())
+                tweets_per_second = float(result_count) / seconds_diff
+                self.write("""
+                <div style="text-align: center">
+                <div style="font-size: 72px">%s</div>
+                <div style="font-size: 144px">%.02f</div>
+                <div style="font-size: 24px">tweets per second</div>
+                </div>""" % (self.get_argument('q'), tweets_per_second))
+                self.finish()
+
 
 if __name__ == "__main__":
-	tornado.options.parse_command_line()
-	app = tornado.web.Application(handlers=[(r"/", IndexHandler)])
-	http_server = tornado.httpserver.HTTPServer(app)
-	http_server.listen(options.port)
-	tornado.ioloop.IOLoop.instance().start()
+    tornado.options.parse_command_line()
+    app = tornado.web.Application(handlers=[(r"/", IndexHandler)], debug = True)
+    http_server = tornado.httpserver.HTTPServer(app)
+    http_server.listen(options.port)
+    tornado.ioloop.IOLoop.current().start()

--- a/asynchronous_web_services/async_http/tweet_rate_async.py
+++ b/asynchronous_web_services/async_http/tweet_rate_async.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 import tornado.httpserver
 import tornado.ioloop
 import tornado.options
@@ -12,66 +14,69 @@ import datetime
 import time
 
 from tornado.options import define, options
-define('port', default=8000, help = 'run on the given port', type = int)
+define('port', default=8000, help='run on the given port', type=int)
 
 # twitter part
+
 client_key = 'NqHKwxVhm7Fk4257bzgAidOsN'
-client_secret = 'dlOeX6TtGffsdafxqhz46rNRT6kfaPoQEN2qnkknSSodhxPIICnMuMR'
+client_secret = 'dlOeX6TtGfxqhz46rNRT6kfaPoQEN2qnkknSSodhxPIICnMuMR'
 key_secret = '{}:{}'.format(client_key, client_secret).encode('ascii')
 b64_encoded_key = base64.b64encode(key_secret)
 b64_encoded_key = b64_encoded_key.decode('ascii')
 base_url = 'https://api.twitter.com/'
 auth_url = '{}oauth2/token'.format(base_url)
-auth_headers = {
-'Authorization': 'Basic {}'.format(b64_encoded_key),
-'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
-}
-auth_data = {
-'grant_type': 'client_credentials'
-}
-auth_resp = requests.post(auth_url, headers=auth_headers, data=auth_data)
+auth_headers = {'Authorization': 'Basic {}'.format(b64_encoded_key),
+                'Content-Type':
+                'application/x-www-form-urlencoded;charset=UTF-8'}
+auth_data = {'grant_type': 'client_credentials'}
+auth_resp = requests.post(auth_url, headers=auth_headers,
+                          data=auth_data)
 access_token = auth_resp.json()['access_token']
-search_headers = {
-'Authorization': 'Bearer {}'.format(access_token)    
-}
+search_headers = {'Authorization': 'Bearer {}'.format(access_token)}
 search_url = '{}1.1/search/tweets.json?'.format(base_url)
 
-class IndexHandler(tornado.web.RequestHandler):
-        @tornado.web.asynchronous
-        def get(self):
-                query = self.get_argument('q') 
-                search_params = {
-                'q': query,
-                'result_type': 'recent',
-                'count': 100
-                }
 
-                client = tornado.httpclient.AsyncHTTPClient()
-                response = client.fetch(search_url+urllib.parse.urlencode(search_params), headers=search_headers,
-                                        callback = self.on_response)
-        
-        def on_response(self, response):       
-                body = json.loads(response.body)
-                result_count = len(body['statuses'])
-                now = datetime.datetime.utcnow()
-                raw_oldest_tweet_at = body['statuses'][-1]['created_at']
-                oldest_tweet_at = datetime.datetime.strptime(raw_oldest_tweet_at,
-                        "%a %b %d %H:%M:%S +0000 %Y")
-                seconds_diff = time.mktime(now.timetuple()) - \
-                        time.mktime(oldest_tweet_at.timetuple())
-                tweets_per_second = float(result_count) / seconds_diff
-                self.write("""
+class IndexHandler(tornado.web.RequestHandler):
+
+    @tornado.web.asynchronous
+    def get(self):
+        query = self.get_argument('q')
+        search_params = {'q': query, 'result_type': 'recent',
+                         'count': 100}
+
+        client = tornado.httpclient.AsyncHTTPClient()
+        response = client.fetch(search_url +
+                                urllib.parse.urlencode(search_params),
+                                headers=search_headers,
+                                callback=self.on_response)
+
+    def on_response(self, response):
+        body = json.loads(response.body)
+        result_count = len(body['statuses'])
+        now = datetime.datetime.utcnow()
+        raw_oldest_tweet_at = body['statuses'][-1]['created_at']
+        oldest_tweet_at = \
+            datetime.datetime.strptime(
+                raw_oldest_tweet_at,
+                '%a %b %d %H:%M:%S +0000 %Y'
+                )
+        seconds_diff = time.mktime(now.timetuple()) \
+            - time.mktime(oldest_tweet_at.timetuple())
+        tweets_per_second = float(result_count) / seconds_diff
+        self.write("""
                 <div style="text-align: center">
                 <div style="font-size: 72px">%s</div>
                 <div style="font-size: 144px">%.02f</div>
                 <div style="font-size: 24px">tweets per second</div>
-                </div>""" % (self.get_argument('q'), tweets_per_second))
-                self.finish()
+                </div>"""
+                   % (self.get_argument('q'), tweets_per_second))
+        self.finish()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     tornado.options.parse_command_line()
-    app = tornado.web.Application(handlers=[(r"/", IndexHandler)], debug = True)
+    app = tornado.web.Application(handlers=[(r"/", IndexHandler)],
+                                  debug=True)
     http_server = tornado.httpserver.HTTPServer(app)
     http_server.listen(options.port)
     tornado.ioloop.IOLoop.current().start()

--- a/asynchronous_web_services/async_http/tweet_rate_gen.py
+++ b/asynchronous_web_services/async_http/tweet_rate_gen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 import tornado.httpserver
 import tornado.ioloop
 import tornado.options
@@ -13,65 +15,66 @@ import datetime
 import time
 
 from tornado.options import define, options
-define('port', default=8000, help = 'run on the given port', type = int)
-
-
+define('port', default=8000, help='run on the given port', type=int)
 
 # twitter part
+
 client_key = 'NqHKwxVhm7Fk4257bzgAidOsN'
-client_secret = 'dlOeX6TtGffsdafxqhz46rNRT6kfaPoQEN2qnkknSSodhxPIICnMuMR'
+client_secret = 'dlOeX6TtGfxqhz46rNRT6kfaPoQEN2qnkknSSodhxPIICnMuMR'
 key_secret = '{}:{}'.format(client_key, client_secret).encode('ascii')
 b64_encoded_key = base64.b64encode(key_secret)
 b64_encoded_key = b64_encoded_key.decode('ascii')
 base_url = 'https://api.twitter.com/'
 auth_url = '{}oauth2/token'.format(base_url)
-auth_headers = {
-'Authorization': 'Basic {}'.format(b64_encoded_key),
-'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
-}
-auth_data = {
-'grant_type': 'client_credentials'
-}
-auth_resp = requests.post(auth_url, headers=auth_headers, data=auth_data)
+auth_headers = {'Authorization': 'Basic {}'.format(b64_encoded_key),
+                'Content-Type':
+                'application/x-www-form-urlencoded;charset=UTF-8'}
+auth_data = {'grant_type': 'client_credentials'}
+auth_resp = requests.post(auth_url, headers=auth_headers,
+                          data=auth_data)
 access_token = auth_resp.json()['access_token']
-search_headers = {
-'Authorization': 'Bearer {}'.format(access_token)    
-}
+search_headers = {'Authorization': 'Bearer {}'.format(access_token)}
 search_url = '{}1.1/search/tweets.json?'.format(base_url)
 
+
 class IndexHandler(tornado.web.RequestHandler):
-        @tornado.web.asynchronous
-        @tornado.gen.coroutine
-        def get(self):
-                query = self.get_argument('q') 
-                search_params = {
-                'q': query,
-                'result_type': 'recent',
-                'count': 100
-                }
-                client = tornado.httpclient.AsyncHTTPClient()
-                response = yield tornado.gen.Task(client.fetch, search_url+urllib.parse.urlencode(search_params), headers=search_headers)     
-                body = json.loads(response.body)
-                result_count = len(body['statuses'])
-                now = datetime.datetime.utcnow()
-                raw_oldest_tweet_at = body['statuses'][-1]['created_at']
-                oldest_tweet_at = datetime.datetime.strptime(raw_oldest_tweet_at,
-                        "%a %b %d %H:%M:%S +0000 %Y")
-                seconds_diff = time.mktime(now.timetuple()) - \
-                        time.mktime(oldest_tweet_at.timetuple())
-                tweets_per_second = float(result_count) / seconds_diff
-                self.write("""
+
+    @tornado.web.asynchronous
+    @tornado.gen.coroutine
+    def get(self):
+        query = self.get_argument('q')
+        search_params = {'q': query, 'result_type': 'recent',
+                         'count': 100}
+        client = tornado.httpclient.AsyncHTTPClient()
+        response = (yield tornado.gen.Task(client.fetch, search_url +
+                    urllib.parse.urlencode(search_params),
+                    headers=search_headers))
+        body = json.loads(response.body)
+        result_count = len(body['statuses'])
+        now = datetime.datetime.utcnow()
+        raw_oldest_tweet_at = body['statuses'][-1]['created_at']
+        oldest_tweet_at = \
+            datetime.datetime.strptime(
+                raw_oldest_tweet_at,
+                '%a %b %d %H:%M:%S +0000 %Y'
+                )
+        seconds_diff = time.mktime(now.timetuple()) \
+            - time.mktime(oldest_tweet_at.timetuple())
+        tweets_per_second = float(result_count) / seconds_diff
+        self.write("""
                 <div style="text-align: center">
                 <div style="font-size: 72px">%s</div>
                 <div style="font-size: 144px">%.02f</div>
                 <div style="font-size: 24px">tweets per second</div>
-                </div>""" % (query, tweets_per_second))
-                self.finish()
+                </div>"""
+                   % (query, tweets_per_second))
+        self.finish()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     tornado.options.parse_command_line()
-    app = tornado.web.Application(handlers=[(r"/", IndexHandler)], debug = True)
+    app = tornado.web.Application(handlers=[(r"/", IndexHandler)],
+                                  debug=True)
     http_server = tornado.httpserver.HTTPServer(app)
     http_server.listen(options.port)
     tornado.ioloop.IOLoop.current().start()

--- a/asynchronous_web_services/async_http/tweet_rate_gen.py
+++ b/asynchronous_web_services/async_http/tweet_rate_gen.py
@@ -5,43 +5,73 @@ import tornado.web
 import tornado.httpclient
 import tornado.gen
 
-import urllib
+import base64
+import requests
+import urllib.parse
 import json
 import datetime
 import time
 
 from tornado.options import define, options
-define("port", default=8000, help="run on the given port", type=int)
+define('port', default=8000, help = 'run on the given port', type = int)
+
+
+
+# twitter part
+client_key = 'NqHKwxVhm7Fk4257bzgAidOsN'
+client_secret = 'dlOeX6TtGffsdafxqhz46rNRT6kfaPoQEN2qnkknSSodhxPIICnMuMR'
+key_secret = '{}:{}'.format(client_key, client_secret).encode('ascii')
+b64_encoded_key = base64.b64encode(key_secret)
+b64_encoded_key = b64_encoded_key.decode('ascii')
+base_url = 'https://api.twitter.com/'
+auth_url = '{}oauth2/token'.format(base_url)
+auth_headers = {
+'Authorization': 'Basic {}'.format(b64_encoded_key),
+'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+}
+auth_data = {
+'grant_type': 'client_credentials'
+}
+auth_resp = requests.post(auth_url, headers=auth_headers, data=auth_data)
+access_token = auth_resp.json()['access_token']
+search_headers = {
+'Authorization': 'Bearer {}'.format(access_token)    
+}
+search_url = '{}1.1/search/tweets.json?'.format(base_url)
 
 class IndexHandler(tornado.web.RequestHandler):
-	@tornado.web.asynchronous
-	@tornado.gen.engine
-	def get(self):
-		query = self.get_argument('q')
-		client = tornado.httpclient.AsyncHTTPClient()
-		response = yield tornado.gen.Task(client.fetch,
-				"http://search.twitter.com/search.json?" + \
-				urllib.urlencode({"q": query.encode('utf8'), "result_type": "recent", "rpp": 100}))
-		body = json.loads(response.body)
-		result_count = len(body['results'])
-		now = datetime.datetime.utcnow()
-		raw_oldest_tweet_at = body['results'][-1]['created_at']
-		oldest_tweet_at = datetime.datetime.strptime(raw_oldest_tweet_at,
-				"%a, %d %b %Y %H:%M:%S +0000")
-		seconds_diff = time.mktime(now.timetuple()) - \
-				time.mktime(oldest_tweet_at.timetuple())
-		tweets_per_second = float(result_count) / seconds_diff
-		self.write("""
-<div style="text-align: center">
-	<div style="font-size: 72px">%s</div>
-	<div style="font-size: 144px">%.02f</div>
-	<div style="font-size: 24px">tweets per second</div>
-</div>""" % (query, tweets_per_second))
-		self.finish()
+        @tornado.web.asynchronous
+        @tornado.gen.coroutine
+        def get(self):
+                query = self.get_argument('q') 
+                search_params = {
+                'q': query,
+                'result_type': 'recent',
+                'count': 100
+                }
+                client = tornado.httpclient.AsyncHTTPClient()
+                response = yield tornado.gen.Task(client.fetch, search_url+urllib.parse.urlencode(search_params), headers=search_headers)     
+                body = json.loads(response.body)
+                result_count = len(body['statuses'])
+                now = datetime.datetime.utcnow()
+                raw_oldest_tweet_at = body['statuses'][-1]['created_at']
+                oldest_tweet_at = datetime.datetime.strptime(raw_oldest_tweet_at,
+                        "%a %b %d %H:%M:%S +0000 %Y")
+                seconds_diff = time.mktime(now.timetuple()) - \
+                        time.mktime(oldest_tweet_at.timetuple())
+                tweets_per_second = float(result_count) / seconds_diff
+                self.write("""
+                <div style="text-align: center">
+                <div style="font-size: 72px">%s</div>
+                <div style="font-size: 144px">%.02f</div>
+                <div style="font-size: 24px">tweets per second</div>
+                </div>""" % (query, tweets_per_second))
+                self.finish()
+
 
 if __name__ == "__main__":
-	tornado.options.parse_command_line()
-	app = tornado.web.Application(handlers=[(r"/", IndexHandler)])
-	http_server = tornado.httpserver.HTTPServer(app)
-	http_server.listen(options.port)
-	tornado.ioloop.IOLoop.instance().start()
+    tornado.options.parse_command_line()
+    app = tornado.web.Application(handlers=[(r"/", IndexHandler)], debug = True)
+    http_server = tornado.httpserver.HTTPServer(app)
+    http_server.listen(options.port)
+    tornado.ioloop.IOLoop.current().start()

--- a/databases/bookstore/burts_books_db.py
+++ b/databases/bookstore/burts_books_db.py
@@ -25,7 +25,7 @@ class Application(tornado.web.Application):
 			ui_modules={"Book": BookModule},
 			debug=True,
 			)
-		conn = pymongo.MongoClient("localhost", 27017) # MongoClient for pymongo version 2.8.0+
+		conn = pymongo.MongoClient("localhost", 27017)
 		self.db = conn["bookstore"]
 		tornado.web.Application.__init__(self, handlers, **settings)
 

--- a/databases/bookstore/burts_books_db.py
+++ b/databases/bookstore/burts_books_db.py
@@ -25,7 +25,7 @@ class Application(tornado.web.Application):
 			ui_modules={"Book": BookModule},
 			debug=True,
 			)
-		conn = pymongo.Connection("localhost", 27017)
+		conn = pymongo.MongoClient("localhost", 27017) # MongoClient for pymongo version 2.8.0+
 		self.db = conn["bookstore"]
 		tornado.web.Application.__init__(self, handlers, **settings)
 

--- a/databases/bookstore/burts_books_rwdb.py
+++ b/databases/bookstore/burts_books_rwdb.py
@@ -27,7 +27,7 @@ class Application(tornado.web.Application):
 			ui_modules={"Book": BookModule},
 			debug=True,
 			)
-		conn = pymongo.MongoClient("localhost", 27017) # MongoClient for pymongo version 2.8.0+
+		conn = pymongo.MongoClient("localhost", 27017)
 		self.db = conn["bookstore"]
 		tornado.web.Application.__init__(self, handlers, **settings)
 

--- a/databases/bookstore/burts_books_rwdb.py
+++ b/databases/bookstore/burts_books_rwdb.py
@@ -27,7 +27,7 @@ class Application(tornado.web.Application):
 			ui_modules={"Book": BookModule},
 			debug=True,
 			)
-		conn = pymongo.Connection("localhost", 27017)
+		conn = pymongo.MongoClient("localhost", 27017) # MongoClient for pymongo version 2.8.0+
 		self.db = conn["bookstore"]
 		tornado.web.Application.__init__(self, handlers, **settings)
 

--- a/databases/bookstore/burts_books_rwdb_single.py
+++ b/databases/bookstore/burts_books_rwdb_single.py
@@ -28,7 +28,7 @@ class Application(tornado.web.Application):
 			ui_modules={"Book": BookModule},
 			debug=True,
 			)
-		conn = pymongo.MongoClient("localhost", 27017) # MongoClient for pymongo version 2.8.0+
+		conn = pymongo.MongoClient("localhost", 27017)
 		self.db = conn["bookstore"]
 		tornado.web.Application.__init__(self, handlers, **settings)
 

--- a/databases/bookstore/burts_books_rwdb_single.py
+++ b/databases/bookstore/burts_books_rwdb_single.py
@@ -28,7 +28,7 @@ class Application(tornado.web.Application):
 			ui_modules={"Book": BookModule},
 			debug=True,
 			)
-		conn = pymongo.Connection("localhost", 27017)
+		conn = pymongo.MongoClient("localhost", 27017) # MongoClient for pymongo version 2.8.0+
 		self.db = conn["bookstore"]
 		tornado.web.Application.__init__(self, handlers, **settings)
 

--- a/databases/definitions_readonly.py
+++ b/databases/definitions_readonly.py
@@ -11,7 +11,7 @@ define("port", default=8000, help="run on the given port", type=int)
 class Application(tornado.web.Application):
 	def __init__(self):
 		handlers = [(r"/(\w+)", WordHandler)]
-		conn = pymongo.Connection("localhost", 27017)
+		conn = pymongo.MongoClient("localhost", 27017) # MongoClient for pymongo version 2.8.0+
 		self.db = conn["example"]
 		tornado.web.Application.__init__(self, handlers, debug=True)
 

--- a/databases/definitions_readwrite.py
+++ b/databases/definitions_readwrite.py
@@ -11,7 +11,7 @@ define("port", default=8000, help="run on the given port", type=int)
 class Application(tornado.web.Application):
 	def __init__(self):
 		handlers = [(r"/(\w+)", WordHandler)]
-		conn = pymongo.Connection("localhost", 27017)
+		conn = pymongo.MongoClient("localhost", 27017) # MongoClient for pymongo version 2.8.0+
 		self.db = conn["definitions"]
 		tornado.web.Application.__init__(self, handlers, debug=True)
 

--- a/databases/definitions_readwrite.py
+++ b/databases/definitions_readwrite.py
@@ -11,7 +11,7 @@ define("port", default=8000, help="run on the given port", type=int)
 class Application(tornado.web.Application):
 	def __init__(self):
 		handlers = [(r"/(\w+)", WordHandler)]
-		conn = pymongo.MongoClient("localhost", 27017) # MongoClient for pymongo version 2.8.0+
+		conn = pymongo.MongoClient("localhost", 27017)
 		self.db = conn["definitions"]
 		tornado.web.Application.__init__(self, handlers, debug=True)
 


### PR DESCRIPTION
Fixed #17  and #18 

The chapter five - async web services contains the outdated web API of twitter there is another PR but that didn't work for me, so i followed [the new API from twitter](https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets) and this [article](http://benalexkeen.com/interacting-with-the-twitter-api-using-python/) to fix those scripts and they worked after some tinkering.

The chapter four contains  - `Connection` which has been changed to `MongoClient` more over [here](https://github.com/dcrosta/professor/issues/13#issuecomment-360423175)

also changed `@tornado.gen.engine` to `@tornado.gen.coroutine` , because of new tornado version.

Please do let me know if there is any more that I can do.

P.S the keys for twitter wont work.